### PR TITLE
fix: setup.py package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name="lxml-stubs",
     version="0.1",
-    package_data={"lxml-stubs": glob.glob("lxml-stubs/*.pyi")},
+    package_data={"lxml-stubs": glob.glob1("lxml-stubs", "*.pyi")},
     packages=["lxml-stubs"],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Package data needs file names without full path.

```
>>> glob.glob1("lxml-stubs", "*.pyi")
['cssselect.pyi', 'etree.pyi', '__init__.pyi', 'objectify.pyi']
```