### PR TITLE
Fix installed package and update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ Eventually, it should become a PEP 561-style stubs package.
 
 ## Usage
 
-To use these stubs, clone this repo and point your type checker to it. For example, to use them in
-[mypy](http://github.com/python/mypy), you can set the `$MYPYPATH` environment variable or set
-`mypy_path = /path/to/lxml-stubs` in your `mypy.ini`.
+To use these stubs with [mypy](https://github.com/python/mypy), you have to
+install the `lxml-stubs` package.
+
+If you want to use the stubs as-is, you can build and install the package
+directly from its repository:
+
+    $ pip install https://github.com/lxml/lxml-stubs.git
+
+If you want to make local modifications, you can clone this repository and
+tell `pip` to install a link to the cloned source tree:
+
+    $ pip install -e /path/to/lxml-stubs
 
 ## Contributing
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
-import glob
 from distutils.core import setup
 
 setup(
     name="lxml-stubs",
     version="0.1",
-    package_data={"lxml-stubs": glob.glob("lxml-stubs/*.pyi")},
+    package_data={"lxml-stubs": ["*.pyi"]},
     packages=["lxml-stubs"],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
     ],
+    zip_safe=False
 )


### PR DESCRIPTION
To use a stub-only package with mypy, it needs to be installed: you cannot just put it in `MYPYPATH`. However, the installed package did not actually contain the stubs because of a problem in `setup.py`.

The first commit fixes `setup.py` and the second commit updates the `README` to tell users to install the package.

Closes #1