### PR TITLE
Overload etree.tostring return type depending on encoding

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -21,7 +21,10 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Protocol
+from typing_extensions import (
+    Protocol,
+    Literal,
+)
 
 # dummy for missing stubs
 def __getattr__(name: str) -> Any: ...
@@ -57,6 +60,16 @@ _NSMap = Union[Dict[Union[bytes, None], bytes], Dict[Union[str, None], str]]
 _xpath = Union["XPath", _AnyStr]
 _OptionalNamespace = Optional[Mapping[str, Any]]
 _T = TypeVar("_T")
+_KnownEncodings = Literal[
+    'ASCII',
+    'ascii',
+    'UTF-8',
+    'utf-8',
+    'UTF8',
+    'utf8',
+    'US-ASCII',
+    'us-ascii',
+]
 
 class ElementChildIterator(Iterator["_Element"]):
     def __iter__(self) -> "ElementChildIterator": ...
@@ -379,6 +392,36 @@ def parse(
 def fromstring(
     text: _AnyStr, parser: XMLParser = ..., *, base_url: _AnyStr = ...
 ) -> _Element: ...
+@overload
+def tostring(
+    element_or_tree: Union[_Element, _ElementTree],
+    encoding: Union[Type[str], Literal["unicode"]],
+    method: str = ...,
+    xml_declaration: bool = ...,
+    pretty_print: bool = ...,
+    with_tail: bool = ...,
+    standalone: bool = ...,
+    doctype: str = ...,
+    exclusive: bool = ...,
+    with_comments: bool = ...,
+    inclusive_ns_prefixes: Any = ...,
+) -> str: ...
+@overload
+def tostring(
+    element_or_tree: Union[_Element, _ElementTree],
+    # Should be anything but "unicode", cannot be typed
+    encoding: Optional[_KnownEncodings] = None,
+    method: str = ...,
+    xml_declaration: bool = ...,
+    pretty_print: bool = ...,
+    with_tail: bool = ...,
+    standalone: bool = ...,
+    doctype: str = ...,
+    exclusive: bool = ...,
+    with_comments: bool = ...,
+    inclusive_ns_prefixes: Any = ...,
+) -> bytes: ...
+@overload
 def tostring(
     element_or_tree: Union[_Element, _ElementTree],
     encoding: Union[str, type] = ...,

--- a/test-data/test-etree.yml
+++ b/test-data/test-etree.yml
@@ -43,6 +43,18 @@
         from lxml import etree
         string = etree.tostring(etree.Element("foo"))
         reveal_type(string)  # N: Revealed type is 'builtins.bytes'
+-   case: etree_tostring_bytes_utf8
+    disable_cache: true
+    main: |
+        from lxml import etree
+        string = etree.tostring(etree.Element("foo"), encoding="utf8")
+        reveal_type(string)  # N: Revealed type is 'builtins.bytes'
+-   case: etree_tostring_any_unknown
+    disable_cache: true
+    main: |
+        from lxml import etree
+        string = etree.tostring(etree.Element("foo"), encoding="latin_1")
+        reveal_type(string)  # N: Revealed type is 'Union[builtins.str, builtins.bytes]'
 -   case: etree_tostring_string_str
     disable_cache: true
     main: |

--- a/test-data/test-etree.yml
+++ b/test-data/test-etree.yml
@@ -37,3 +37,21 @@
         parser = etree.XMLParser()
         element = parser.makeelement("foobar")
         reveal_type(element)  # N: Revealed type is 'lxml.etree._Element'
+-   case: etree_tostring_bytes
+    disable_cache: true
+    main: |
+        from lxml import etree
+        string = etree.tostring(etree.Element("foo"))
+        reveal_type(string)  # N: Revealed type is 'builtins.bytes'
+-   case: etree_tostring_string_str
+    disable_cache: true
+    main: |
+        from lxml import etree
+        string = etree.tostring(etree.Element("foo"), encoding=str)
+        reveal_type(string)  # N: Revealed type is 'builtins.str'
+-   case: etree_tostring_string_unicode
+    disable_cache: true
+    main: |
+        from lxml import etree
+        string = etree.tostring(etree.Element("foo"), encoding="unicode")
+        reveal_type(string)  # N: Revealed type is 'builtins.str'


### PR DESCRIPTION
I've made the return type of `etree.tostring` `str` when `"unicode"` or `str` is passed as encoding, and `bytes` when a few hardcoded encodings are given, and still `Union[bytes, str]` in the general case.

AFAIK it's not possible to properly say "any type but "unicode" or str", but I think this should already help for most usecases.