### PR TITLE
collect stub files recursively when building stub-only package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
+import pathlib
 import re
-from setuptools import setup
 
+from setuptools import setup
 
 tests_require = [
     "pytest>=6.0.0",
@@ -17,13 +18,18 @@ with open("README.md") as fh:
     )
 
 
+def find_stubs():
+    stubs_root = pathlib.Path(__file__).parent / "lxml-stubs"
+    return [str(p.relative_to(stubs_root)) for p in stubs_root.rglob("*.pyi")]
+
+
 setup(
     name="lxml-stubs",
     version="0.1.1",
     description="Type annotations for the lxml package",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_data={"lxml-stubs": ["*.pyi"]},
+    package_data={"lxml-stubs": find_stubs()},
     packages=["lxml-stubs"],
     tests_require=tests_require,
     extras_require={"test": tests_require},

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import pathlib
 import re
 
 from setuptools import setup
@@ -17,19 +16,13 @@ with open("README.md") as fh:
         flags=re.M | re.S,
     )
 
-
-def find_stubs():
-    stubs_root = pathlib.Path(__file__).parent / "lxml-stubs"
-    return [str(p.relative_to(stubs_root)) for p in stubs_root.rglob("*.pyi")]
-
-
 setup(
     name="lxml-stubs",
     version="0.1.1",
     description="Type annotations for the lxml package",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_data={"lxml-stubs": find_stubs()},
+    package_data={"lxml-stubs": ["*.pyi", "*/*.pyi"]},
     packages=["lxml-stubs"],
     tests_require=tests_require,
     extras_require={"test": tests_require},

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ extras = test
 basepython = python3.7
 deps =
     black
-    isort[toml]
+    isort>=5
 skip_install = true
 commands =
     isort --check-only --diff lxml-stubs


### PR DESCRIPTION
The reason for this is that `setuptools` doesn't support globbing in `package_data` (see https://github.com/pypa/setuptools/issues/1806), so stub files in subpackages will be collected via neither `*.pyi` nor `**/*.pyi`.

Please verify the solution using `pathlib` is viable. In its current form, this PR would restrict building of wheels and installation of source dists on Python>=3.4. The `python_requires` specifier is not set, but since the current wheels have `py3` tag, I assume the solution is fine - if not, I can rewrite it using `os.walk` or switch to globbing in `MANIFEST.in`.