### PR TITLE
Add stubs for `etree.HTMLParser`, `etree.HTML` and `etree.XML`

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -317,6 +317,23 @@ class XMLParser(_FeedParser):
     ) -> None: ...
     resolvers = ...  # type: _ResolverRegistry
 
+class HTMLParser(_FeedParser):
+    def __init__(
+        self,
+        encoding: Optional[_AnyStr] = ...,
+        collect_ids: bool = ...,
+        compact: bool = ...,
+        huge_tree: bool = ...,
+        no_network: bool = ...,
+        recover: bool = ...,
+        remove_blank_text: bool = ...,
+        remove_comments: bool = ...,
+        remove_pis: bool = ...,
+        schema: Optional[XMLSchema] = ...,
+        strip_cdata: bool = ...,
+        target: Optional[ParserTarget] = ...,
+    ) -> None: ...
+
 class _ResolverRegistry:
     def add(self, resolver: Resolver) -> None: ...
     def remove(self, resolver: Resolver) -> None: ...
@@ -382,6 +399,16 @@ def ProcessingInstruction(
 
 PI = ProcessingInstruction
 
+def HTML(
+    text: _AnyStr,
+    parser: Optional[HTMLParser] = ...,
+    base_url: Optional[_AnyStr] = ...,
+) -> _Element: ...
+def XML(
+    text: _AnyStr,
+    parser: Optional[XMLParser] = ...,
+    base_url: Optional[_AnyStr] = ...,
+) -> _Element: ...
 def cleanup_namespaces(
     tree_or_element: Union[_Element, _ElementTree],
     top_nsmap: Optional[_NSMap] = ...,

--- a/test-data/test-etree.yml
+++ b/test-data/test-etree.yml
@@ -37,6 +37,14 @@
         parser = etree.XMLParser()
         element = parser.makeelement("foobar")
         reveal_type(element)  # N: Revealed type is 'lxml.etree._Element'
+
+-   case: etree_htmlparser_makeelement
+    disable_cache: true
+    main: |
+        from lxml import etree
+        parser = etree.HTMLParser()
+        element = parser.makeelement("foobar")
+        reveal_type(element)  # N: Revealed type is 'lxml.etree._Element'
 -   case: etree_tostring_bytes
     disable_cache: true
     main: |
@@ -74,3 +82,15 @@
         # if mypy doesn't raise an "Incompatible types in assignment"
         from lxml import etree
         target: etree.ParserTarget = etree.TreeBuilder()
+-   case: etree_HTML_returns_element
+    disable_cache: true
+    main: |
+        from lxml import etree
+        document = etree.HTML("<doc></doc>", parser=etree.HTMLParser(), base_url="http://example.com/")
+        reveal_type(document)  # N: Revealed type is 'lxml.etree._Element'
+-   case: etree_XML_returns_element
+    disable_cache: true
+    main: |
+        from lxml import etree
+        document = etree.XML("<doc></doc>", parser=etree.XMLParser(), base_url="http://example.com/")
+        reveal_type(document)  # N: Revealed type is 'lxml.etree._Element'


### PR DESCRIPTION
Hello, I've added stubs for the `lxml.etree.HTMLParser` class , as well as for the `lxml.etree.HTML` and `lxml.etree.XML` functions.

Docs I used:

* https://lxml.de/api/lxml.etree.HTMLParser-class.html
* https://lxml.de/api/lxml.etree-module.html#HTML
* https://lxml.de/api/lxml.etree-module.html#XML

First PR here, feedback appreciated.