### PR TITLE
Add iter method to _ElementTree

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -164,6 +164,9 @@ class _ElementTree:
     parser = ...  # type: XMLParser
     def getpath(self, element: _Element) -> str: ...
     def getroot(self) -> _Element: ...
+    def iter(
+        self, tag: Optional[_TagName] = ..., *tags: _TagName
+    ) -> Iterable[_Element]: ...
     def write(
         self,
         file: Union[_AnyStr, IO[Any]],


### PR DESCRIPTION
Similar to `_Element.iter`, there is `_ElementTree.iter` method. The API is the same as the `_Element.iter` - it returns `Iterable[_Element]`

https://lxml.de/apidoc/lxml.etree.html#lxml.etree._ElementTree.iter