### PR TITLE
Removes a test dependency that can't be installed

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
-  format:
+  checks:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -6,6 +6,11 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toxenv:
+          - format
+          - mypy
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -15,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: pip install tox
     - name: Validate formatting
-      run: tox -e format
+      run: tox -e ${{ matrix.toxenv }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -39,4 +39,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox
-      run: tox
+      run: tox -e py

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 
 tests_require = [
     "pytest>=6.0.0",
-    "pytest-mypy-plugins==1.4.0",
     "coverage[toml]==5.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ import re
 from setuptools import setup
 
 tests_require = [
-    "pytest>=6.0.0",
     "coverage[toml]==5.2",
+    "pytest>=6.0.0",
+    "pytest-mypy-plugins==1.9.3"
 ]
 
 with open("README.md") as fh:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = format,mypy,py36,py37,py38,py39
 
 [gh-actions]
 python =
@@ -21,3 +21,11 @@ skip_install = true
 commands =
     isort --check-only --diff lxml-stubs
     black --check --diff -v lxml-stubs/
+
+[testenv:mypy]
+basepython = python3.9
+deps =
+    mypy
+skip_install = true
+commands =
+    mypy lxml-stubs

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,5 @@
 [tox]
-envlist = format,mypy,py36,py37,py38,py39
-
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
+envlist = format,mypy,py36,py37,py38,py39,py310
 
 [testenv]
 commands = pytest {posargs}


### PR DESCRIPTION
This is a first approach to make the test suite run again.

I think it's fine not to rely on a pytest-plugin that requires a templating language and run mypy directly instead.

However, 

- that mypy run yields errors
- ~~at least locally the package can't be installed for Python 3.6~~ (not an issue w/ the CI platform)
- ~~at least locally~~ pytest doesn't run tests; i leave that to someone acquainted with yaml-based test definitions