### PR TITLE
Change iterfind namespace to namespaces

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -153,7 +153,7 @@ class _Element(Iterable["_Element"], Sized):
     ) -> Iterable[_Element]: ...
     iterdescendants = iter
     def iterfind(
-        self, path: str, namespace: _OptionalNamespace = None
+        self, path: str, namespaces: _OptionalNamespace = None
     ) -> Iterator["_Element"]: ...
     def itersiblings(
         self,


### PR DESCRIPTION
`iterfind` take the kwarg `namespaces` not `namespace`

https://github.com/lxml/lxml/blob/745ac2685ca05c67afbf2a1dde24e4d48bd86dcd/src/lxml/etree.pyx#L1575