### PR TITLE
Change `_tag` argument type of `Element` and `SubElement` to `_TagName`

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -416,14 +416,14 @@ class XSLT:
 
 def Comment(text: Optional[_AnyStr] = ...) -> _Comment: ...
 def Element(
-    _tag: _AnyStr,
+    _tag: _TagName,
     attrib: Optional[_DictAnyStr] = ...,
     nsmap: Optional[_NSMap] = ...,
     **extra: _AnyStr
 ) -> _Element: ...
 def SubElement(
     _parent: _Element,
-    _tag: _AnyStr,
+    _tag: _TagName,
     attrib: Optional[_DictAnyStr] = ...,
     nsmap: Optional[_NSMap] = ...,
     **extra: _AnyStr

--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -317,7 +317,7 @@ class _BaseParser:
     def copy(self) -> _BaseParser: ...
     def makeelement(
         self,
-        _tag: _AnyStr,
+        _tag: _TagName,
         attrib: Optional[Union[_DictAnyStr, _Attrib]] = ...,
         nsmap: Optional[_NSMap] = ...,
         **_extra: Any


### PR DESCRIPTION
The `_tag` argument can also be `QName`.