### PR TITLE
Minimal Pyright config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,12 @@ include_trailing_comma = true
 balanced_wrapping = true
 default_section = "THIRDPARTY"
 use_parentheses = true
+
+[tool.pyright]
+include = ["lxml-stubs"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "/.tox",
+]
+reportPrivateUsage = false


### PR DESCRIPTION
The `reportPrivateUsage` config is about the class of warning illustrated below:

![圖片](https://user-images.githubusercontent.com/83110/153874399-8ab82940-8a7d-4c2e-b29c-133afc3a868c.png)

Though mypy doesn't complain, pyright doesn't like exporting private variables, classes or types. However, given the widespread use of `etree._Element` (and a bunch of others), it makes sense to supress this kind of warning for pyright.