### PR TITLE
Add parse method for _ElementTree class

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -244,8 +244,8 @@ class _ElementTree:
     def parse(
         self,
         source: _FileSource,
-        parser: XMLParser | None = ...,
-        base_url: _AnyStr | None = ...,
+        parser: Optional[XMLParser] = ...,
+        base_url: Optional[_AnyStr] = ...,
     ) -> _Element: ...
     def write(
         self,

--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -241,6 +241,12 @@ class _ElementTree:
     def iter(
         self, tag: Optional[_TagSelector] = ..., *tags: _TagSelector
     ) -> Iterable[_Element]: ...
+    def parse(
+        self,
+        source: _FileSource,
+        parser: XMLParser | None = ...,
+        base_url: _AnyStr | None = ...,
+    ) -> _Element: ...
     def write(
         self,
         file: _FileSource,


### PR DESCRIPTION
I noticed this method was missing. Let me know if I should adjust anything!