### PR TITLE
Pin pytest to a version compatible with 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 tests_require = [
     "coverage[toml]==5.2",
-    "pytest>=6.0.0",
+    "pytest>=6.0.0,<7.1.0",
     "pytest-mypy-plugins==1.9.3"
 ]
 


### PR DESCRIPTION
Testing now breaks because pytest 7.2.x is being installed. This release
doesn't support Python 3.6 (since 7.1.x), and drops the `py` module as a
dependency breaking the mypy plugin. If 3.6 support is still desirable,
then this PR fixes these issues by pinning pytest.

- Pytest 7.1.x drops Python 3.6 support
- Pytest 7.2.x drops the `py` dependency that the mypy plugin depends on

The latter is fixed in pytest-mypy-plugins 1.10.1, but the 1.10.x series
of the plugin also drops 3.6 support.
