### PR TITLE
Use recursion in the _TagSelector collection hint

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -39,13 +39,7 @@ _AnySmartStr = Union[
 ]
 _TagName = Union[str, bytes, QName]
 # _TagSelector also allows Element, Comment, ProcessingInstruction
-_TagSelector = Union[
-    str,
-    bytes,
-    QName,
-    Collection[Any],  # really Collection[_TagSelector]
-    Any,
-]
+_TagSelector = Union[_TagName, Collection[_TagSelector], Any]
 # XPath object - http://lxml.de/xpathxslt.html#xpath-return-values
 _XPathObject = Union[
     bool,

--- a/test-data/test-etree.yml
+++ b/test-data/test-etree.yml
@@ -34,7 +34,7 @@
     main: |
         from lxml import etree
         element = etree.Element("foo")
-        reveal_type(element.iterchildren)  # N: Revealed type is "def (tag: Union[builtins.str, builtins.bytes, lxml.etree.QName, typing.Collection[Any], Any, None] =, *tags: Union[builtins.str, builtins.bytes, lxml.etree.QName, typing.Collection[Any], Any], *, reversed: builtins.bool =) -> typing.Iterator[lxml.etree._Element]"
+        reveal_type(element.iterchildren)  # N: Revealed type is "def (tag: Union[Union[builtins.str, builtins.bytes, lxml.etree.QName], typing.Collection[Union[builtins.str, builtins.bytes, lxml.etree.QName, typing.Collection[...], ...]], Any, None] =, *tags: Union[builtins.str, builtins.bytes, lxml.etree.QName, typing.Collection[...], ...], *, reversed: builtins.bool =) -> typing.Iterator[lxml.etree._Element]"
         result = element.iterchildren("my-attr")
         reveal_type(result)  # N: Revealed type is "typing.Iterator[lxml.etree._Element]"
 


### PR DESCRIPTION
There is no reason to use Any inside Collection here.

Also, use the `_TagName` alias for the `str | bytes | Qname` portion of the union.
