### PR TITLE
Ensure modern mypy versions are used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import setup
 tests_require = [
     "coverage[toml]>=7.2.5",
     "pytest>=7.3.0",
-    "pytest-mypy-plugins>=1.10.1"
+    "pytest-mypy-plugins>=1.10.1",
+    "mypy>=1.2.0"
 ]
 
 with open("README.md") as fh:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 [testenv:mypy]
 basepython = python3.10
 deps =
-    mypy
+    mypy>=1.2.0
 skip_install = true
 commands =
     mypy lxml-stubs


### PR DESCRIPTION
Recursive type hints need mypy 0.991 at the very least. There are other
speed and stability improvements in the 1.x series such that it's best
to require the latest version here.
