### PR TITLE
Fix type comment in `Element_.sourceline`

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -227,7 +227,7 @@ class _Element(Iterable["_Element"], Sized):
     text = ...  # type: Optional[str]
     tail = ...  # type: Optional[str]
     prefix = ...  # type: str
-    sourceline = ...  # Optional[int]
+    sourceline = ...  # type: Optional[int]
     @property
     def nsmap(self) -> Dict[Optional[str], str]: ...
     base = ...  # type: Optional[str]


### PR DESCRIPTION
This resolves #93 by correctly defining the type of `Element_.sourceline`

Thanks!