### PR TITLE
Make `XMLSchema` inputs optional

### DIFF
--- a/lxml-stubs/etree.pyi
+++ b/lxml-stubs/etree.pyi
@@ -457,8 +457,8 @@ class Resolver:
 class XMLSchema(_Validator):
     def __init__(
         self,
-        etree: _ElementOrTree = ...,
-        file: _FileSource = ...,
+        etree: Optional[_ElementOrTree] = ...,
+        file: Optional[_FileSource] = ...,
     ) -> None: ...
     def __call__(self, etree: _ElementOrTree) -> bool: ...
 


### PR DESCRIPTION
The parameters `etree` and `file` of the `XMLSchema` constructor are documented as `None` by default, so `None` should be a valid value.