### PR TITLE
Add `lxml.builder`

### DIFF
--- a/lxml-stubs/builder.pyi
+++ b/lxml-stubs/builder.pyi
@@ -2,7 +2,7 @@ from typing import Any, Callable, Mapping, Optional, Protocol, TypeVar, Union
 
 from lxml.etree import _Element, _NSMapArg, _TagName, CDATA
 
-type _Child = Union[_Element, str, CDATA, Mapping[str, str]]
+type _Child = Union[_Element, str, CDATA, dict[str, str]]
 
 _T = TypeVar("_T")
 
@@ -17,7 +17,7 @@ class _TaggedElementMaker(Protocol):
 class ElementMaker:
     def __init__(
         self,
-        typemap: Optional[dict[type[_T], Callable[[_Element, _T], Any]]] = None,
+        typemap: Optional[Mapping[type[_T], Callable[[_Element, _T], Any]]] = None,
         namespace: Optional[str] = None,
         nsmap: Optional[_NSMapArg] = None,
         makeelement: Optional[_MakeElement] = None,

--- a/lxml-stubs/builder.pyi
+++ b/lxml-stubs/builder.pyi
@@ -1,0 +1,28 @@
+from typing import Any, Callable, Mapping, Optional, Protocol, TypeVar, Union
+
+from lxml.etree import _Element, _NSMapArg, _TagName, CDATA
+
+type _Child = Union[_Element, str, CDATA, Mapping[str, str]]
+
+_T = TypeVar("_T")
+
+class _MakeElement(Protocol):
+    def __call__(
+        self, __tag: _TagName, *, nsmap: Optional[_NSMapArg] = None
+    ) -> _Element: ...
+
+class _TaggedElementMaker(Protocol):
+    def __call__(self, *children: _Child, **attrib: str) -> _Element: ...
+
+class ElementMaker:
+    def __init__(
+        self,
+        typemap: Optional[dict[type[_T], Callable[[_Element, _T], Any]]] = None,
+        namespace: Optional[str] = None,
+        nsmap: Optional[_NSMapArg] = None,
+        makeelement: Optional[_MakeElement] = None,
+    ): ...
+    def __call__(self, tag: _TagName, *children: _Child, **attrib: str) -> _Element: ...
+    def __getattr__(self, tag: _TagName) -> _TaggedElementMaker: ...
+
+E = ElementMaker()


### PR DESCRIPTION
Implements #30.

This covers general use of the builder module, though type hints from ElementMaker's typemap is too complicated for me to figure out.

This includes a reference to `lxml.etree.CDATA` which is currently undefined. Is that okay to leave as is or should it be removed until that's added?